### PR TITLE
Stabilize DBC exit builder tests for offline execution

### DIFF
--- a/tests/dbcExitAction.test.ts
+++ b/tests/dbcExitAction.test.ts
@@ -31,6 +31,28 @@ class MockConnection extends Connection {
       rentEpoch: 0,
     } as any;
   }
+
+  override async getLatestBlockhash(): Promise<{ blockhash: string; lastValidBlockHeight: number }> {
+    return {
+      blockhash: Keypair.generate().publicKey.toBase58(),
+      lastValidBlockHeight: 123,
+    };
+  }
+
+  override async simulateTransaction(
+    _tx?: unknown,
+    _config?: unknown
+  ): Promise<{
+    value: { logs: string[]; unitsConsumed: number; err: null };
+  }> {
+    return {
+      value: {
+        logs: ['mock simulate'],
+        unitsConsumed: 5000,
+        err: null,
+      },
+    };
+  }
 }
 const connection = new MockConnection(
   process.env.RPC_URL || 'https://api.mainnet-beta.solana.com',

--- a/tests/services.test.ts
+++ b/tests/services.test.ts
@@ -22,15 +22,14 @@ describe('services: connection + meteora', () => {
   });
 
   it('connectionService health returns false on slot error', async () => {
-    const fake = { getSlot: vi.fn().mockRejectedValue(new Error('slot fail')) };
     vi.mock('@solana/web3.js', async (orig) => {
       const base: any = await orig();
       class FakeConnection extends base.Connection {
         constructor() {
           super('http://localhost:1234');
         }
-        getSlot(): Promise<number> {
-          return fake.getSlot();
+        override getSlot(): Promise<number> {
+          return Promise.reject(new Error('slot fail'));
         }
       }
       return { ...base, Connection: FakeConnection };


### PR DESCRIPTION
## Summary
- extend the DBC exit action test connection mock to provide deterministic blockhash and simulation responses so it no longer calls the network
- simplify the connection service slot failure test by inlining a mocked Connection subclass that rejects getSlot

## Testing
- pnpm test:run
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_b_68c9e8b6bea8832a9b7dfd098b94f7ca